### PR TITLE
Make the default http protocol https

### DIFF
--- a/account/conf.py
+++ b/account/conf.py
@@ -49,6 +49,7 @@ class AccountAppConf(AppConf):
     SETTINGS_REDIRECT_URL = "account_settings"
     NOTIFY_ON_PASSWORD_CHANGE = True
     DELETION_EXPUNGE_HOURS = 48
+    DEFAULT_HTTP_PROTOCOL = 'https'
     HOOKSET = "account.hooks.AccountDefaultHookSet"
     TIMEZONES = TIMEZONES
     LANGUAGES = LANGUAGES

--- a/account/models.py
+++ b/account/models.py
@@ -207,7 +207,7 @@ class SignupCode(models.Model):
         signup_code_used.send(sender=result.__class__, signup_code_result=result)
 
     def send(self, **kwargs):
-        protocol = getattr(settings, "DEFAULT_HTTP_PROTOCOL", "http")
+        protocol = settings.ACCOUNT_DEFAULT_PROTOCOL
         current_site = kwargs["site"] if "site" in kwargs else Site.objects.get_current()
         if "signup_url" not in kwargs:
             signup_url = "{0}://{1}{2}?{3}".format(
@@ -328,7 +328,7 @@ class EmailConfirmation(models.Model):
 
     def send(self, **kwargs):
         current_site = kwargs["site"] if "site" in kwargs else Site.objects.get_current()
-        protocol = getattr(settings, "DEFAULT_HTTP_PROTOCOL", "http")
+        protocol = settings.ACCOUNT_DEFAULT_PROTOCOL
         activate_url = "{0}://{1}{2}".format(
             protocol,
             current_site.domain,

--- a/account/views.py
+++ b/account/views.py
@@ -101,7 +101,7 @@ class PasswordMixin(object):
         return default_redirect(self.request, fallback_url, **kwargs)
 
     def send_password_email(self, user):
-        protocol = getattr(settings, "DEFAULT_HTTP_PROTOCOL", "http")
+        protocol = settings.ACCOUNT_DEFAULT_PROTOCOL
         current_site = get_current_site(self.request)
         ctx = {
             "user": user,
@@ -632,7 +632,7 @@ class PasswordResetView(FormView):
 
     def send_email(self, email):
         User = get_user_model()
-        protocol = getattr(settings, "DEFAULT_HTTP_PROTOCOL", "http")
+        protocol = settings.ACCOUNT_DEFAULT_PROTOCOL
         current_site = get_current_site(self.request)
         email_qs = EmailAddress.objects.filter(email__iexact=email)
         for user in User.objects.filter(pk__in=email_qs.values("user")):

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -125,6 +125,12 @@ Default: ``"account.callbacks.account_delete_expunge"``
 
 Default: ``48``
 
+
+``ACCOUNT_DEFAULT_HTTP_PROTOCOL``
+=================================
+
+Default: ``https``
+
 ``ACCOUNT_HOOKSET``
 ===================
 


### PR DESCRIPTION
As any login site should be using https in this day and age
https should be used as a default, furthermore this won't really
affect local development as the links are in an email.

Making it https by default prevents the developer of forgetting this
easy to miss setting.