### PR TITLE
Use the user model as the email model.

### DIFF
--- a/account/auth_backends.py
+++ b/account/auth_backends.py
@@ -7,6 +7,10 @@ from account.utils import get_user_lookup_kwargs
 
 
 class UsernameAuthenticationBackend(ModelBackend):
+    """
+    When the email model is the User, this authentication works just fine
+    for authenticating the user through email
+    """
 
     def authenticate(self, request, username=None, password=None, **kwargs):
         if username is None or password is None:
@@ -28,6 +32,8 @@ class UsernameAuthenticationBackend(ModelBackend):
 class EmailAuthenticationBackend(ModelBackend):
 
     def authenticate(self, request, username=None, password=None, **kwargs):
+        # TODO, remove primary true, username shouldn't be necessary either?
+        # should use email model. This probably doesn't need to be modified
         qs = EmailAddress.objects.filter(Q(primary=True) | Q(verified=True))
 
         if username is None or password is None:

--- a/account/conf.py
+++ b/account/conf.py
@@ -1,5 +1,6 @@
 import importlib
 
+from django.apps import apps as django_apps
 from django.conf import settings  # noqa
 from django.core.exceptions import ImproperlyConfigured
 
@@ -22,8 +23,29 @@ def load_path_attr(path):
     return attr
 
 
-class AccountAppConf(AppConf):
+def get_email_model():
+    """
+    Return the Email model that is active in this project.
+    This should either be the user model, or the email model provided
+    in the project
+    """
+    try:
+        return django_apps.get_model(settings.ACCOUNT_EMAIL_MODEL, require_ready=False)
+    except ValueError:
+        raise ImproperlyConfigured("ACCOUNT_EMAIL_MODEL must be of the form 'app_label.model_name'")
+    except LookupError:
+        raise ImproperlyConfigured(
+            "ACCOUNT_EMAIL_MODEL refers to model '%s' that has not been installed" % settings.ACCOUNT_EMAIL_MODEL
+        )
 
+
+def user_as_email():
+    return settings.ACCOUNT_EMAIL_MODEL == settings.AUTH_USER_MODEL
+
+
+class AccountAppConf(AppConf):
+    # TODO can we make a check that it's easier the user model or this model?
+    EMAIL_MODEL = "account.EmailAddress"
     OPEN_SIGNUP = True
     LOGIN_URL = "account_login"
     LOGOUT_URL = "account_logout"

--- a/account/migrations/0001_initial.py
+++ b/account/migrations/0001_initial.py
@@ -59,7 +59,7 @@ class Migration(migrations.Migration):
                 ('created', models.DateTimeField(default=django.utils.timezone.now)),
                 ('sent', models.DateTimeField(null=True)),
                 ('key', models.CharField(unique=True, max_length=64)),
-                ('email_address', models.ForeignKey(to='account.EmailAddress', on_delete=models.CASCADE)),
+                ('email_address', models.ForeignKey(to=settings.ACCOUNT_EMAIL_MODEL, on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'email confirmation',

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -293,3 +293,12 @@ are saved forever, allowing password history checking for new passwords.
 For an authenticated user, ``ExpiredPasswordMiddleware`` prevents retrieving or posting
 to any page except the password change page and log out page when the user password is expired.
 However, if the user is "staff" (can access the Django admin site), the password check is skipped.
+
+
+Using email from User model
+============================
+
+TODO
+
+The user model needs a field `verified`, it should also have a property `email`, which is used
+as an alias for the username which is the email.


### PR DESCRIPTION
You can customize the user model so that the email
is the username, in cases like that it may be superflouous
to have multiple emails, in fact it may not be desirable.

For applications like that it's easier to only use the email
address defined in the user model.